### PR TITLE
Moving the scss file to public/css folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
     "sass": "^1.77.8"
   },
   "scripts": {
-    "build": "sass ckanext/fjelltopp_theme/public/scss/fjelltopp-theme.scss ckanext/fjelltopp_theme/public/css/fjelltopp-theme.css"
+    "build": "sass ckanext/fjelltopp_theme/public/css/fjelltopp-theme.scss ckanext/fjelltopp_theme/public/css/fjelltopp-theme.css"
   }
 }


### PR DESCRIPTION
## Description

A small change that will allow Pycharm's Filewatcher to generate the .css and .css.map files in the css folder.

Closes https://github.com/fjelltopp/ckanext-fjelltopp-theme/issues/1

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
