### PR TITLE
fix: remove ccsrewerite from webassets

### DIFF
--- a/ckanext/fjelltopp_theme/assets/webassets.yml
+++ b/ckanext/fjelltopp_theme/assets/webassets.yml
@@ -1,26 +1,22 @@
 fjelltopp-theme:
-  filters: cssrewrite
   output: fjelltopp-theme/%(version)s-fjelltopp-theme.css
   contents:
     - css/fjelltopp-theme.css
 
 
 fjelltopp-theme-fonts:
-  filters: cssrewrite
   output: fjelltopp-theme/%(version)s-fjelltopp-theme.css
   contents:
     - css/inter.css
 
 
 fjelltopp-theme-palette:
-  filters: cssrewrite
   output: fjelltopp-theme/%(version)s-fjelltopp-theme.css
   contents:
     - css/palette.css
 
 
 fjelltopp-theme-extended:
-  filters: cssrewrite
   output: fjelltopp-theme/%(version)s-fjelltopp-theme-extended.css
   contents:
     - css/fjelltopp-theme-extended.css


### PR DESCRIPTION
## Description

After an afternoon of debugging with @jonathansberry we have discovered that removing the rewrite css filter seems essential to deploying to staging and production.

See also:

- https://github.com/ckan/ckan/issues/7369
- https://github.com/miracle2k/webassets/issues/387

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
