### PR TITLE
feat: add resource edit template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ docs/_build/
 
 # virtualenv
 .venv/
+
+# Compiled CSS
+ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.css
+ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.css.map
+ckanext/fjelltopp_theme/assets/css/fjelltopp-theme-extended.css
+ckanext/fjelltopp_theme/assets/css/fjelltopp-theme-extended.css.map

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1086,6 +1086,13 @@ a:hover {
     padding: 10px 40px;
 }
 
+
+@media only screen and (max-width: map-get(map-get($breakpoints, xs), max)) {
+    :not(.input-group-btn) > .btn {
+        margin-bottom: 10px;
+    }
+}
+
 .btn-primary {
   background-color: config.$secondary;
   border-color: config.$secondary;

--- a/ckanext/fjelltopp_theme/templates/package/resource_edit.html
+++ b/ckanext/fjelltopp_theme/templates/package/resource_edit.html
@@ -1,0 +1,14 @@
+{% extends "package/resource_edit_base.html" %}
+
+{% block subtitle %}{{ _('Edit') }} {{ g.template_title_delimiter }} {{ h.resource_display_name(res) }} {{ g.template_title_delimiter }} {{ h.dataset_display_name(pkg) }}{% endblock %}
+
+{% block form %}
+  {% snippet 'package/snippets/resource_edit_form.html',
+    data=data,
+    errors=errors,
+    error_summary=error_summary,
+    pkg_name=pkg.name,
+    form_action=form_action,
+    resource_form_snippet=resource_form_snippet,
+    dataset_type=dataset_type %}
+{% endblock %}


### PR DESCRIPTION
## Description

Adds the template used in AFRO for the resource edit page to the theme. Screenshots taken in Zambia for ease.

On laptop:
![image](https://github.com/user-attachments/assets/9be6ef8d-68f8-484c-898e-a1a912200b56)

On phone:
![image](https://github.com/user-attachments/assets/d68dd5d4-5228-4513-a1ba-b083a92370f8)

closes fjelltopp/zarr-ckan#147

## Checklist

- [x] The Github ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
