### PR TITLE
Adding a new resource to an existing dataset causes a bug

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1317,6 +1317,15 @@ a.thumbnail.active {
     font-size: inherit;
 }
 
+/* this adjust the add resource page for existing dataset */
+@media (min-width: 768px) {
+  .wrapper::before {
+      content: none;
+      display: none;
+    }
+}
+
+
 /* pills , badges */
 .pill, .module-narrow .nav-item.active a, .module-narrow .nav-item.active a:hover {
     background-color: config.$secondary;

--- a/ckanext/fjelltopp_theme/templates/package/new_resource_not_draft.html
+++ b/ckanext/fjelltopp_theme/templates/package/new_resource_not_draft.html
@@ -4,3 +4,8 @@
 
 {% block secondary_content %}
 {% endblock %}
+
+
+{% block form %}
+    {% snippet resource_form_snippet, data=data, errors=errors, error_summary=error_summary, include_metadata=false, pkg_name=pkg_name, stage=stage, dataset_type=dataset_type %}
+{% endblock %}

--- a/ckanext/fjelltopp_theme/templates/package/new_resource_not_draft.html
+++ b/ckanext/fjelltopp_theme/templates/package/new_resource_not_draft.html
@@ -1,3 +1,6 @@
 {% ckan_extends %}
 
-{% block maintag %}<div class="main resource-editor">{% endblock %}
+{% block maintag %}<div class="main update-dataset-page">{% endblock %}
+
+{% block secondary_content %}
+{% endblock %}


### PR DESCRIPTION
## Description

Add resource page for an existing dataset now correctly uses the JS uploader.

![image](https://github.com/user-attachments/assets/59ddc069-76e0-43a8-b65c-8bbda3f47d40)

Closes https://github.com/fjelltopp/zarr-ckan/issues/165

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
