### PR TITLE
24 - New group or organization pages have issues because of new UI

### DIFF
--- a/ckanext/fjelltopp_theme/templates/group/edit_base.html
+++ b/ckanext/fjelltopp_theme/templates/group/edit_base.html
@@ -30,7 +30,9 @@
                                     {% if self.content_action() | trim %}
                                       <div class="content_action">
                                         {% block content_action %}
+                                            {%  if group_dict %}
                                             {{ super() }}
+                                            {% endif %}
                                         {% endblock %}
                                       </div>
                                     {% endif %}
@@ -40,7 +42,11 @@
             </div>
         </div>
         <ul class="nav nav-tabs">
-            {% block content_primary_nav %}{{ super() }}{% endblock %}
+            {% block content_primary_nav %}
+                {%  if group_dict %}
+                {{ super() }}
+                {% endif %}
+            {% endblock %}
         </ul>
     </div>
 </div>

--- a/ckanext/fjelltopp_theme/templates/group/edit_base.html
+++ b/ckanext/fjelltopp_theme/templates/group/edit_base.html
@@ -31,7 +31,7 @@
                                       <div class="content_action">
                                         {% block content_action %}
                                             {%  if group_dict %}
-                                            {{ super() }}
+                                                {{ super() }}
                                             {% endif %}
                                         {% endblock %}
                                       </div>
@@ -44,7 +44,7 @@
         <ul class="nav nav-tabs">
             {% block content_primary_nav %}
                 {%  if group_dict %}
-                {{ super() }}
+                    {{ super() }}
                 {% endif %}
             {% endblock %}
         </ul>

--- a/ckanext/fjelltopp_theme/templates/organization/edit_base.html
+++ b/ckanext/fjelltopp_theme/templates/organization/edit_base.html
@@ -16,7 +16,6 @@
                               {% block breadcrumb %}
                                   <ol class="breadcrumb">
                                     {% snippet 'snippets/home_breadcrumb_item.html' %}
-
                                     {% block breadcrumb_content %}
                                         {% if not group %}
                                             {% set group = group_dict %}

--- a/ckanext/fjelltopp_theme/templates/organization/edit_base.html
+++ b/ckanext/fjelltopp_theme/templates/organization/edit_base.html
@@ -16,6 +16,7 @@
                               {% block breadcrumb %}
                                   <ol class="breadcrumb">
                                     {% snippet 'snippets/home_breadcrumb_item.html' %}
+
                                     {% block breadcrumb_content %}
                                         {% if not group %}
                                             {% set group = group_dict %}
@@ -30,7 +31,9 @@
                                     {% if self.content_action() | trim %}
                                       <div class="content_action">
                                         {% block content_action %}
+                                            {%  if group_dict %}
                                             {{ super() }}
+                                            {% endif %}
                                         {% endblock %}
                                       </div>
                                     {% endif %}
@@ -40,7 +43,11 @@
             </div>
         </div>
         <ul class="nav nav-tabs">
-            {% block content_primary_nav %}{{ super() }}{% endblock %}
+            {% block content_primary_nav %}
+                {%  if group_dict %}
+                {{ super() }}
+                {% endif %}
+            {% endblock %}
         </ul>
     </div>
 </div>

--- a/ckanext/fjelltopp_theme/templates/organization/edit_base.html
+++ b/ckanext/fjelltopp_theme/templates/organization/edit_base.html
@@ -31,7 +31,7 @@
                                       <div class="content_action">
                                         {% block content_action %}
                                             {%  if group_dict %}
-                                            {{ super() }}
+                                                {{ super() }}
                                             {% endif %}
                                         {% endblock %}
                                       </div>
@@ -44,7 +44,7 @@
         <ul class="nav nav-tabs">
             {% block content_primary_nav %}
                 {%  if group_dict %}
-                {{ super() }}
+                    {{ super() }}
                 {% endif %}
             {% endblock %}
         </ul>


### PR DESCRIPTION
## Description
group/new.html and organization/new.html extends base_form_page.html which extends edit_base.html. 

The new UI updates edit_base.html to create the tabs (in promoted) and the manage button which are not relevant for group / organization creation.

Closes https://github.com/fjelltopp/ckanext-fjelltopp-theme/issues/24

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
