### PR TITLE
feat: remove shadowed wrapper

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -31,7 +31,41 @@ body {
     min-height: 80vh;
     padding-top: 32px;
     padding-bottom: 64px;
-    background-color: config.$primary10;
+    background: config.$primary10;
+}
+
+.main.organization-about,
+.main.organization-activity-stream,
+.main.organization-update,
+.main.package-read,
+.main.update-dataset-page,
+.main.package-pages,
+.main.group-pages,
+.main.group-update,
+.main.group-about,
+.main.group-activity-stream,
+.main.user-read-tokens,
+.main.user-activity-stream,
+.main.user-update,
+.main.any-other,
+{
+    background: config.$light;
+}
+
+.main.user-read li.dataset-item {
+    border: 0;
+    background-color: config.$light;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+    padding: 24px;
+    border-radius: 8px;
+}
+
+.topic-top-square {
+    border: config.$primary 1px solid;
+}
+
+.module-content {
+    padding-top: 0;
 }
 
 .homepage .hero, .main.user-profile-page {
@@ -2864,7 +2898,7 @@ div.main.group-read .group-read-packages,
         bottom: 0;
         left: 0;
         width: 25%;
-        border-right: 1px solid config.$primary25;
+        //border-right: 1px solid config.$primary25;
         z-index: 1;
     }
     .group-activity-stream .wrapper:before,

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -27,12 +27,30 @@ body {
     border-bottom: none;
 }
 
-.main, .homepage .hero {
+.main {
     min-height: 80vh;
     padding-top: 32px;
     padding-bottom: 64px;
-    background: config.$light;
+    background-color: config.$primary10;
 }
+
+.homepage .hero, .main.user-profile-page {
+    min-height: 80vh;
+    padding-top: 32px;
+    padding-bottom: 64px;
+    background: none;
+    background-color: config.$light;
+}
+
+/* modules */
+aside.secondary .module {
+    background-color: config.$light;
+    margin: 0;
+    width: 100%;
+    padding: 12px;
+    border: config.$primary65 thin solid;
+}
+/* modules */
 
 .homepage .main,
 .homepage .hero,
@@ -666,6 +684,17 @@ footer.site-footer .data-hub-stats {
 
 .site-footer .footer-subscribe-section {
     margin-bottom: 64px;
+}
+
+/* wrapper used on all pages */
+.wrapper {
+    border: 0;
+    box-shadow: none;
+    background-color: transparent;
+}
+
+.wrapper::before {
+    border: none;
 }
 
 /* group box (group page?) template update might be needed as well TODO */
@@ -2136,11 +2165,6 @@ a.thumbnail.active {
     border-right: 0;
 }
 
-.user-profile-page .wrapper {
-    box-shadow: none;
-    border: 0;
-}
-
 .user-profile-page .page-header {
     background-color: config.$light;
 }
@@ -2310,11 +2334,6 @@ ol.breadcrumb {
     }
 }
 
-.dataset.wrapper {
-    border: none;
-    box-shadow: none;
-}
-
 .dataset .secondary {
     padding-left: 39px;
     padding-right: 39px;
@@ -2429,12 +2448,6 @@ ol.breadcrumb {
 
 
 /* search page */
-div.main.search .wrapper {
-    border: 0;
-    box-shadow: none;
-    background-color: transparent;
-}
-
 #content {
     padding-left: 30px;
     padding-right: 30px;
@@ -2448,7 +2461,6 @@ div.main.group-read .group-read-packages,
 {
     min-height: 0;
     padding-bottom: 0;
-    background-color: config.$primary10;
 
     .row > .big-search-form {
     padding-left: 0;
@@ -2516,16 +2528,6 @@ div.main.group-read .group-read-packages,
     }
 
     /* ported */
-     .wrapper {
-        border: 0;
-        box-shadow: none;
-        background-color: transparent;
-    }
-
-     .wrapper::before {
-        border: none;
-    }
-
      .row > .big-search-form {
         padding-left: 0;
         padding-right: 0;
@@ -2842,12 +2844,6 @@ div.main.group-read .group-read-packages,
     border: none;
     border-radius: 0;
     box-shadow: none;
-}
-
-.wrapper {
-    border: config.$primary25 1px solid;
-    box-shadow: 0 0 0 0.4px config.$primary25;
-
 }
 
 .organization-activity-stream .secondary, .group-activity-stream .secondary {

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -688,7 +688,7 @@ footer.site-footer .data-hub-stats {
 
 /* wrapper used on all pages */
 .wrapper {
-    border: 0;
+    border: none;
     box-shadow: none;
     background-color: transparent;
 }

--- a/ckanext/fjelltopp_theme/templates/package/base.html
+++ b/ckanext/fjelltopp_theme/templates/package/base.html
@@ -2,6 +2,8 @@
 
 {% block wrapper_class %} dataset {% endblock %}
 
+{% block maintag %}<div class="main group-pages">{% endblock %}
+
 {% block promoted_toolbar %}
 
 <div class="dataset promoted-background promoted-breadcrumbs {% block fx_bg %}dynamic-wave-background{% endblock %}">

--- a/ckanext/fjelltopp_theme/templates/user/activity_stream.html
+++ b/ckanext/fjelltopp_theme/templates/user/activity_stream.html
@@ -1,0 +1,3 @@
+{% ckan_extends %}
+
+{% block maintag %}<div class="main user-activity-stream">{% endblock %}

--- a/ckanext/fjelltopp_theme/templates/user/api_tokens.html
+++ b/ckanext/fjelltopp_theme/templates/user/api_tokens.html
@@ -1,5 +1,7 @@
 {%  ckan_extends %}
 
+{% block maintag %}<div class="main user-read-tokens">{% endblock %}
+
 {% block breadcrumb %}
     {% if self.breadcrumb_content() | trim %}
       <ol class="profile-page breadcrumb">


### PR DESCRIPTION
## Description

This PR does 2 things:

1. it merges all of the `.wrapper` CSS into one bit - wrappers should be identical across pages so I think this makes sense. This change definitely belongs here.
2. it sets the `.main` background colour to `primary10` (keeping the `.homepage .hero` as `light`. This requires a knock-on to make sure that sidebar modules have a background colour of `light`. I am not 100% sure if this change belongs here or in ZaRR - thoughts @A-Souhei?

relates (but is not dependent on) fjelltopp/ckanext-zarr#44

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
