### PR TITLE
193 - Fix "add dataset is a drop down for no reason"

### DIFF
--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -2,7 +2,7 @@
 
 {% set classes_ = classes_ | default('') %}
 {% set dataset_type = dataset_type if dataset_type else h.default_package_type() %}
-{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or _("Add Data")%}
+{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or _("Add Data") %}
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -6,7 +6,7 @@
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}
-    {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary' + classes_, icon='plus-square' %}
+    {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary ' + classes_, icon='plus-square' %}
 {% else %}
-    {% link_for link_label, named_route=route_name, class_='btn btn-primary' + classes_, icon='plus-square' %}
+    {% link_for link_label, named_route=route_name, class_='btn btn-primary ' + classes_, icon='plus-square' %}
 {% endif %}

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -2,7 +2,7 @@
 
 {% set classes_ = classes_ | default('') %}
 {% set dataset_type = dataset_type if dataset_type else h.default_package_type() %}
-{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or  _("Add Data")%}
+{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or _("Add Data")%}
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -1,0 +1,12 @@
+{# Adds 'Add Dataset' button #}
+
+{% set classes_ = classes_ | default('') %}
+{% set dataset_type = dataset_type if dataset_type else h.default_package_type() %}
+{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or _("Add " + dataset_type|title) %}
+{% set route_name = dataset_type ~ '.new' %}
+
+{% if group %}
+    {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary' + classes_, icon='plus-square' %}
+{% else %}
+    {% link_for link_label, named_route=route_name, class_='btn btn-primary' + classes_, icon='plus-square' %}
+{% endif %}

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -2,7 +2,7 @@
 
 {% set classes_ = classes_ | default('') %}
 {% set dataset_type = dataset_type if dataset_type else h.default_package_type() %}
-{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or _("Add " + dataset_type|title) %}
+{% set link_label = h.humanize_entity_type('packages', dataset_type, 'add link') or  _("Add Data")%}
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}

--- a/ckanext/fjelltopp_theme/templates/snippets/dataset_selector.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/dataset_selector.html
@@ -1,11 +1,18 @@
-<div class="dropdown">
-  <button class="btn btn-primary dropdown-toggle" type="button" id="addDatasetMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    <i class="fa fa-plus-square"></i> {{_('Add Dataset')}}
-  </button>
-  <div class="dropdown-menu" aria-labelledby="addDatasetMenuButton">
+{% set classes_ = classes_ | default('') %}  {# for dashboard dataset #}
 
+{% set schema_count = h.scheming_dataset_schemas() | count  %}
+
+{% if schema_count > 1 %}
+<div class="dropdown">
+  <button class="btn btn-primary dropdown-toggle {{ style_ }}" type="button" id="addDatasetMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <i class="fa fa-plus-square"></i> {{_('Add Data')}}
+  </button>
+  <div class="dropdown-menu {{ class_ }}" aria-labelledby="addDatasetMenuButton">
     {% for schema in h.scheming_dataset_schemas().keys() %}
       {% snippet 'snippets/add_dataset.html', dataset_type=schema %}
     {% endfor %}
   </div>
 </div>
+{% else %}
+    {% snippet 'snippets/add_dataset.html', classes_=classes_, dataset_type=schema %}
+{% endif %}

--- a/ckanext/fjelltopp_theme/templates/snippets/dataset_selector.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/dataset_selector.html
@@ -4,7 +4,7 @@
 
 {% if schema_count > 1 %}
 <div class="dropdown">
-  <button class="btn btn-primary dropdown-toggle {{ style_ }}" type="button" id="addDatasetMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+  <button class="btn btn-primary dropdown-toggle {{ classes_ }}" type="button" id="addDatasetMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
     <i class="fa fa-plus-square"></i> {{_('Add Data')}}
   </button>
   <div class="dropdown-menu {{ class_ }}" aria-labelledby="addDatasetMenuButton">

--- a/ckanext/fjelltopp_theme/templates/user/dashboard_datasets.html
+++ b/ckanext/fjelltopp_theme/templates/user/dashboard_datasets.html
@@ -9,10 +9,9 @@
     {% if not user_dict.datasets %}
         <small class="text-muted fs-5">{{ _("You haven’t created any datasets")}}</small>
         {% if h.check_access('package_create') %}
-            {% link_for _('Add Dataset'), named_route='dataset.new', class_="btn btn-primary dashboard-add-dataset-btn" %}
+            {% snippet 'snippets/dataset_selector.html', classes_='btn btn-primary dashboard-add-dataset-btn' %}
         {% endif %}
     {% endif %}
-
     </h2>
 {% endblock %}
 


### PR DESCRIPTION
## Description

- `Add Dataset` button label renamed to `Add Data`
- When there is only one schema, the `Add Data` will change to 'Add' dataset_type

![image](https://github.com/user-attachments/assets/cf5d561c-717f-4373-9066-725d8df385e6)
![image](https://github.com/user-attachments/assets/101cb2b2-5e1a-484e-9b9f-f70084a85bf0)

Closes https://github.com/fjelltopp/zarr-ckan/issues/193

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
