### PR TITLE
38 -  Data search big input is under the wrapper of left bar

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -2908,3 +2908,8 @@ div.main.group-read .group-read-packages,
 .table {
     border-color: config.$primary10;
 }
+
+/*data search input */
+div.main.search #field-giant-search {
+    z-index: 1;
+}


### PR DESCRIPTION
## Description

The input field in dataset search now gets focus even when clicking at most left of its corner.

![image](https://github.com/user-attachments/assets/d4cb8037-91ce-463b-a512-e6db70a52042)

Closes https://github.com/fjelltopp/ckanext-fjelltopp-theme/issues/38

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
