### PR TITLE
 40 - Cosmetic theme improvements for fjelltopp-theme

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -2913,3 +2913,22 @@ div.main.group-read .group-read-packages,
 div.main.search #field-giant-search {
     z-index: 1;
 }
+
+/* badge configuration */
+.dataset-content > h2.dataset-heading > span.badge:not(:first-of-type) {
+    margin-left: 5px;
+}
+
+.user-profile-page .dataset-content .dataset-heading span.badge {
+    margin-left: 5px;
+    align-self: start;
+    text-transform: uppercase;
+    float: right;
+    @include apply-font-style(400, 12px, 1, inherit, 0.1em, inherit);
+    background: config.$primary25;
+}
+
+.recently-updated .dataset-content .dataset-heading span.badge {
+    display: none;
+}
+

--- a/ckanext/fjelltopp_theme/templates/package/search.html
+++ b/ckanext/fjelltopp_theme/templates/package/search.html
@@ -55,7 +55,7 @@
   {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>
-      <h3>{{ _('Really by:') }}</h3>
+      <h3>{{ _('Sort by:') }}</h3>
       <div class="form-group control-order-by">
         <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
           {% for label, value in sorting %}

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -6,7 +6,7 @@
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}
-    {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary ' + classes_, icon='plus-square' %}
+    {% link_for link_label, named_route=route_name, group=group, class_='dropdown-item' + classes_%}
 {% else %}
-    {% link_for link_label, named_route=route_name, class_='btn btn-primary ' + classes_, icon='plus-square' %}
+    {% link_for link_label, named_route=route_name, class_='dropdown-item ' + classes_ %}
 {% endif %}


### PR DESCRIPTION
## Description

- Hides package_item badges in homepage.
- Fix badges in userprofile.
- "Really by" to "Sort by" in data search.

![image](https://github.com/user-attachments/assets/de48bf74-0b77-4807-a1b3-cd7bd2f1a5ba)
![image](https://github.com/user-attachments/assets/45f1b7b6-0955-4c43-bdb2-e4e486efb50c)
![image](https://github.com/user-attachments/assets/4d549bff-100f-42b7-b523-93b92701da47)

Relates https://github.com/fjelltopp/ckanext-fjelltopp-theme/pull/37
Closes https://github.com/fjelltopp/ckanext-fjelltopp-theme/issues/40
Closes https://github.com/fjelltopp/zarr-ckan/issues/204

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
