### PR TITLE
Fix the 'Add Dataset' button in package/search

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -2932,3 +2932,31 @@ div.main.search #field-giant-search {
     display: none;
 }
 
+/* dataset selector menu */
+.dropdown-menu[aria-labelledby="addDatasetMenuButton"] {
+    padding: 0;
+
+}
+
+.dropdown-menu[aria-labelledby="addDatasetMenuButton"] a {
+    display: list-item;
+    background: config.$light;
+    border: config.$light;
+    color: config.$primary;
+    text-align: left;
+}
+
+.dropdown-menu[aria-labelledby="addDatasetMenuButton"] a:hover {
+    background: config.$primary25;
+}
+
+.dropdown-menu[aria-labelledby="addDatasetMenuButton"] a .fa-plus-square {
+    margin-right: 4px;
+
+}
+
+.dropdown-menu[aria-labelledby="addDatasetMenuButton"] a:not(:first-child) {
+    margin-top: 2px;
+}
+/* dataset selector menu */
+

--- a/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/add_dataset.html
@@ -6,7 +6,7 @@
 {% set route_name = dataset_type ~ '.new' %}
 
 {% if group %}
-    {% link_for link_label, named_route=route_name, group=group, class_='dropdown-item' + classes_%}
+    {% link_for link_label, named_route=route_name, group=group, class_='btn btn-primary ' + classes_, icon='plus-square' %}
 {% else %}
-    {% link_for link_label, named_route=route_name, class_='dropdown-item ' + classes_ %}
+    {% link_for link_label, named_route=route_name, class_='btn btn-primary ' + classes_, icon='plus-square' %}
 {% endif %}


### PR DESCRIPTION
## Description

This Fix will correct the styling of the theme when now there is a bad styling when there is only one schema.
![image](https://github.com/user-attachments/assets/5ec21a72-518b-4ce6-b20b-b4096e59cd19)


Fix:
For 1 schema:
![image](https://github.com/user-attachments/assets/01da34df-81a4-4a6a-8fc1-40f2c909f9b9)


For 2 schemas:
![image](https://github.com/user-attachments/assets/dd3f9473-ea0e-47ce-94fa-69d338c4e66b)


Closes https://github.com/fjelltopp/zarr-ckan/issues/210

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
