### PR TITLE
133 - Configure banner for staging and dev

### DIFF
--- a/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
+++ b/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
@@ -40,8 +40,8 @@
         color: config.$secondary;
     }
     .account-masthead-wrapper .account-masthead .account ul li a:hover {
-        color: config.$light;
-        background-color: config.$secondary;
+        color: config.$primary;
+        background-color: config.$primary10;
     }
     /**/
 }

--- a/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
+++ b/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
@@ -3,10 +3,10 @@
 
 @media only screen and (min-width: 628px) {
       /* hides / shows banner , change bgcolor based on type of deployment*/
-    .deployment-type.staging .account-masthead {
+    .account-masthead-wrapper.staging .account-masthead {
         background-color: config.$light;
     }
-    .deployment-type.production {
+    .account-masthead-wrapper.production {
         display: none !important;
     }
     .dev-banner.development, .dev-banner.sandbox {
@@ -15,31 +15,31 @@
     .production {
         display: none;
     }
-    .deployment-type.staging .account-masthead {
+    .account-masthead-wrapper.staging .account-masthead {
         background-color: config.$light;
     }
-    .deployment-type.development .account-masthead {
+    .account-masthead-wrapper.development .account-masthead {
         background-color: config.$primary;
     }
-    .deployment-type.development .ckan-circle-exclamation {
+    .account-masthead-wrapper.development .ckan-circle-exclamation {
         border: 2px solid config.$primary;
     }
-    .deployment-type.staging .ckan-circle-exclamation {
+    .account-masthead-wrapper.staging .ckan-circle-exclamation {
         border: 2px solid config.$secondary;
     }
-    .deployment-type.development .ckan-circle-exclamation::before {
+    .account-masthead-wrapper.development .ckan-circle-exclamation::before {
         color: config.$primary;
     }
-    .deployment-type.staging .ckan-circle-exclamation::before {
+    .account-masthead-wrapper.staging .ckan-circle-exclamation::before {
         color: config.$secondary;
     }
-    .deployment-type.staging .account-masthead .account ul li {
+    .account-masthead-wrapper.staging .account-masthead .account ul li {
         border-left: none;
     }
-    .deployment-type.staging .account-masthead .account ul li a {
+    .account-masthead-wrapper.staging .account-masthead .account ul li a {
         color: config.$secondary;
     }
-    .deployment-type .account-masthead .account ul li a:hover {
+    .account-masthead-wrapper .account-masthead .account ul li a:hover {
         color: config.$light;
         background-color: config.$secondary;
     }

--- a/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
+++ b/ckanext/fjelltopp_theme/assets/css/_partials/_banner.scss
@@ -1,0 +1,75 @@
+@use 'config' as config;
+
+
+@media only screen and (min-width: 628px) {
+      /* hides / shows banner , change bgcolor based on type of deployment*/
+    .deployment-type.staging .account-masthead {
+        background-color: config.$light;
+    }
+    .deployment-type.production {
+        display: none !important;
+    }
+    .dev-banner.development, .dev-banner.sandbox {
+        background-color: config.$tag !important;
+    }
+    .production {
+        display: none;
+    }
+    .deployment-type.staging .account-masthead {
+        background-color: config.$light;
+    }
+    .deployment-type.development .account-masthead {
+        background-color: config.$primary;
+    }
+    .deployment-type.development .ckan-circle-exclamation {
+        border: 2px solid config.$primary;
+    }
+    .deployment-type.staging .ckan-circle-exclamation {
+        border: 2px solid config.$secondary;
+    }
+    .deployment-type.development .ckan-circle-exclamation::before {
+        color: config.$primary;
+    }
+    .deployment-type.staging .ckan-circle-exclamation::before {
+        color: config.$secondary;
+    }
+    .deployment-type.staging .account-masthead .account ul li {
+        border-left: none;
+    }
+    .deployment-type.staging .account-masthead .account ul li a {
+        color: config.$secondary;
+    }
+    .deployment-type .account-masthead .account ul li a:hover {
+        color: config.$light;
+        background-color: config.$secondary;
+    }
+    /**/
+}
+
+@media only screen and (max-width: 627px) {
+    /* hides / shows banner , change bgcolor based on type of deployment*/
+    .dev-banner-mobile.staging {
+        background-color: config.$light;
+    }
+    .dev-banner-mobile.staging a {
+        color: config.$secondary;
+    }
+    .dev-banner-mobile.staging .ckan-circle-exclamation {
+        color: config.$secondary;
+        border: 2px solid config.$secondary;
+    }
+    .dev-banner-mobile.staging .ckan-circle-exclamation::before {
+        color: config.$secondary;
+    }
+    .dev-banner-mobile.development .ckan-circle-exclamation {
+        color: config.$light;
+        border: 2px solid config.$light;
+    }
+    .dev-banner-mobile.development .ckan-circle-exclamation::before {
+        color: config.$light;
+    }
+    .production {
+        display: none;
+    }
+    /**/
+}

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1676,6 +1676,29 @@ a.thumbnail.active {
         margin-top: -2px;
     }
 
+    /* hides / shows banner , change bgcolor based on type of deployment*/
+    .dev-banner-mobile.staging {
+        background-color: config.$light;
+    }
+    .dev-banner-mobile.staging a {
+        color: config.$secondary;
+    }
+    .dev-banner-mobile.staging .ckan-circle-exclamation {
+        color: config.$secondary;
+        border: 2px solid config.$secondary;
+    }
+    .dev-banner-mobile.staging .ckan-circle-exclamation::before {
+        color: config.$secondary;
+    }
+    .dev-banner-mobile.development .ckan-circle-exclamation {
+        color: config.$light;
+        border: 2px solid config.$light;
+    }
+    .dev-banner-mobile.development .ckan-circle-exclamation::before {
+        color: config.$light;
+    }
+    /**/
+
 }
 
 @media only screen and (min-width: 628px) {
@@ -1698,12 +1721,51 @@ a.thumbnail.active {
     }
     .dev-banner {
         margin-right: auto;
-        background-color: config.$tag;
         pointer-events: none;
     }
+
+    /* hides / shows banner , change bgcolor based on type of deployment*/
+    .deployment-type.production {
+        display: none !important;
+    }
+    .dev-banner.development, .dev-banner.sandbox {
+        background-color: config.$tag !important;
+    }
+    .dev-banner.production {
+        display: none !important;
+    }
+    .deployment-type.staging .account-masthead {
+        background-color: config.$light;
+    }
+    .deployment-type.development .account-masthead {
+        background-color: config.$primary;
+    }
+    .deployment-type.development .ckan-circle-exclamation {
+        border: 2px solid config.$primary;
+    }
+    .deployment-type.staging .ckan-circle-exclamation {
+        border: 2px solid config.$secondary;
+    }
+    .deployment-type.development .ckan-circle-exclamation::before {
+        color: config.$primary;
+    }
+    .deployment-type.staging .ckan-circle-exclamation::before {
+        color: config.$secondary;
+    }
+    .deployment-type.staging .account-masthead .account ul li {
+        border-left: none;
+    }
+    .deployment-type.staging .account-masthead .account ul li a {
+        color: config.$secondary;
+    }
+    .deployment-type .account-masthead .account ul li a:hover {
+        color: config.$light;
+        background-color: config.$secondary;
+    }
+    /**/
+
     ul li.dev-banner a {
         margin-left: 0 !important;
-        background-color: config.$tag !important;
     }
     .dev-banner a .clickable {
         margin-left: 6px;

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1,5 +1,6 @@
 @use '_partials/themes' as *;
 @use '_partials/magic' as *;
+@use '_partials/banner' as *;
 @use '_partials/config' as config;
 @use 'sass:math';
 
@@ -1676,31 +1677,7 @@ a.thumbnail.active {
         margin-top: -2px;
     }
 
-    /* hides / shows banner , change bgcolor based on type of deployment*/
-    .dev-banner-mobile.staging {
-        background-color: config.$light;
-    }
-    .dev-banner-mobile.staging a {
-        color: config.$secondary;
-    }
-    .dev-banner-mobile.staging .ckan-circle-exclamation {
-        color: config.$secondary;
-        border: 2px solid config.$secondary;
-    }
-    .dev-banner-mobile.staging .ckan-circle-exclamation::before {
-        color: config.$secondary;
-    }
-    .dev-banner-mobile.development .ckan-circle-exclamation {
-        color: config.$light;
-        border: 2px solid config.$light;
-    }
-    .dev-banner-mobile.development .ckan-circle-exclamation::before {
-        color: config.$light;
-    }
-    .production {
-        display: none;
-    }
-    /**/
+
 
 }
 
@@ -1727,48 +1704,6 @@ a.thumbnail.active {
         pointer-events: none;
     }
 
-    /* hides / shows banner , change bgcolor based on type of deployment*/
-    .deployment-type.staging .account-masthead {
-        background-color: config.$light;
-    }
-    .deployment-type.production {
-        display: none !important;
-    }
-    .dev-banner.development, .dev-banner.sandbox {
-        background-color: config.$tag !important;
-    }
-    .production {
-        display: none;
-    }
-    .deployment-type.staging .account-masthead {
-        background-color: config.$light;
-    }
-    .deployment-type.development .account-masthead {
-        background-color: config.$primary;
-    }
-    .deployment-type.development .ckan-circle-exclamation {
-        border: 2px solid config.$primary;
-    }
-    .deployment-type.staging .ckan-circle-exclamation {
-        border: 2px solid config.$secondary;
-    }
-    .deployment-type.development .ckan-circle-exclamation::before {
-        color: config.$primary;
-    }
-    .deployment-type.staging .ckan-circle-exclamation::before {
-        color: config.$secondary;
-    }
-    .deployment-type.staging .account-masthead .account ul li {
-        border-left: none;
-    }
-    .deployment-type.staging .account-masthead .account ul li a {
-        color: config.$secondary;
-    }
-    .deployment-type .account-masthead .account ul li a:hover {
-        color: config.$light;
-        background-color: config.$secondary;
-    }
-    /**/
 
     ul li.dev-banner a {
         margin-left: 0 !important;

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1725,6 +1725,9 @@ a.thumbnail.active {
     }
 
     /* hides / shows banner , change bgcolor based on type of deployment*/
+    .deployment-type.staging .account-masthead {
+        background-color: config.$light;
+    }
     .deployment-type.production {
         display: none !important;
     }

--- a/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
+++ b/ckanext/fjelltopp_theme/assets/css/fjelltopp-theme.scss
@@ -1697,6 +1697,9 @@ a.thumbnail.active {
     .dev-banner-mobile.development .ckan-circle-exclamation::before {
         color: config.$light;
     }
+    .production {
+        display: none;
+    }
     /**/
 
 }
@@ -1734,8 +1737,8 @@ a.thumbnail.active {
     .dev-banner.development, .dev-banner.sandbox {
         background-color: config.$tag !important;
     }
-    .dev-banner.production {
-        display: none !important;
+    .production {
+        display: none;
     }
     .deployment-type.staging .account-masthead {
         background-color: config.$light;

--- a/ckanext/fjelltopp_theme/helpers.py
+++ b/ckanext/fjelltopp_theme/helpers.py
@@ -104,3 +104,11 @@ def get_license(license_id):
             return license
     else:
         return {}
+
+
+def get_deployment_info(default='development'):
+    return {
+            "type": toolkit.config.get('ckan.deployment_env.type', default),
+            "message": toolkit.config.get('ckan.deployment_env.banner_message', "BETA - Site under development")
+         }
+

--- a/ckanext/fjelltopp_theme/helpers.py
+++ b/ckanext/fjelltopp_theme/helpers.py
@@ -107,6 +107,9 @@ def get_license(license_id):
 
 
 def get_deployment_info(default='development'):
+    """
+    possible values are development, staging and production, otherwise add more css classes
+    """
     return {
             "type": toolkit.config.get('ckan.deployment_env.type', default),
             "message": toolkit.config.get('ckan.deployment_env.banner_message', "BETA - Site under development")

--- a/ckanext/fjelltopp_theme/helpers.py
+++ b/ckanext/fjelltopp_theme/helpers.py
@@ -111,4 +111,3 @@ def get_deployment_info(default='development'):
             "type": toolkit.config.get('ckan.deployment_env.type', default),
             "message": toolkit.config.get('ckan.deployment_env.banner_message', "BETA - Site under development")
          }
-

--- a/ckanext/fjelltopp_theme/plugin.py
+++ b/ckanext/fjelltopp_theme/plugin.py
@@ -26,7 +26,8 @@ class FjelltoppThemePlugin(plugins.SingletonPlugin):
             'get_datahub_stats': theme_helpers.get_datahub_stats,
             'get_activity_stream_limit': theme_helpers.get_activity_stream_limit,
             'get_user_obj': theme_helpers.get_user_obj,
-            'get_license': theme_helpers.get_license
+            'get_license': theme_helpers.get_license,
+            'get_deployment_info': theme_helpers.get_deployment_info
         }
 
     def update_config(self, config: CKANConfig):

--- a/ckanext/fjelltopp_theme/templates/header.html
+++ b/ckanext/fjelltopp_theme/templates/header.html
@@ -63,7 +63,7 @@
 
 
 {% block header_account %}
-    <div class="deployment-type {{ h.get_deployment_info()['type'] }}">
+    <div class="account-masthead-wrapper {{ h.get_deployment_info()['type'] }}">
         {{ super() }}
     </div>
 {% endblock %}

--- a/ckanext/fjelltopp_theme/templates/header.html
+++ b/ckanext/fjelltopp_theme/templates/header.html
@@ -62,9 +62,8 @@
 {% endblock %}
 
 
-{% block header_wrapper %}
-
-  {{ super() }}
-
-  <div class="fluid-white-bar"></div>
+{% block header_account %}
+    <div class="deployment-type {{ h.get_deployment_info()['type'] }}">
+        {{ super() }}
+    </div>
 {% endblock %}

--- a/ckanext/fjelltopp_theme/templates/snippets/language_selector.html
+++ b/ckanext/fjelltopp_theme/templates/snippets/language_selector.html
@@ -1,29 +1,14 @@
 {% set current_lang = request.environ.CKAN_LANG %}
 
 <div class="dev-banner-container">
-    <div class="dev-banner-mobile row">
-        <a href="{% url_for 'home.about' %}"><span class="ckan-circle-exclamation secondary"></span>BETA - Site under development<span class="clickable">Learn more</span></a>
+    <div class="dev-banner-mobile {{ h.get_deployment_info()['type'] }} row">
+        <a href="{% url_for 'home.about' %}"><span class="ckan-circle-exclamation"></span>{{ _(h.get_deployment_info()['message']) }}<span class="clickable">Learn more</span></a>
     </div>
-    <div class="row">
-          <nav class="account not-authed">
-        <ul class="list-unstyled">
-            <li class="dev-banner"><a href="{% url_for 'home.about' %}"><span class="ckan-circle-exclamation secondary"></span>BETA - Site under development<span class="clickable">Learn more</span></a></li>
-          {% for locale in h.get_available_locales() %}
-            <li>
-              <a href="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>
-              {{ h.format_locale(locale) }}
-            </a>
-            </li>
-          {% endfor %}
-        </ul>
-  </nav>
-    </div>
-
 </div>
 
-<nav class="account not-authed nav-for-large-screen">
+<nav class="account nav-for-large-screen">
     <ul class="list-unstyled">
-        <li class="dev-banner"><a href="{% url_for 'home.about' %}"><span class="ckan-circle-exclamation white"></span>BETA - Site under development<span class="clickable">Learn more</span></a></li>
+        <li class="dev-banner {{ h.get_deployment_info()['type'] }}"><a href="{% url_for 'home.about' %}"><span class="ckan-circle-exclamation"></span>{{ _(h.get_deployment_info()['message']) }}<span class="clickable">Learn more</span></a></li>
       {% for locale in h.get_available_locales() %}
         <li>
           <a href="{% url_for h.current_url(), locale=locale.short_name %}" {% if locale.short_name == current_lang %}selected="selected"{% endif %}>


### PR DESCRIPTION
## Description

Relates https://github.com/fjelltopp/fjelltopp-infrastructure/pull/314
Closes https://github.com/fjelltopp/who-romania-ckan/issues/133

development:
![image](https://github.com/user-attachments/assets/ad98c2b7-3c93-4505-a949-207cac2ce6a6)
![image](https://github.com/user-attachments/assets/251be8af-0d7c-4a32-8746-d7800eeddfee)

staging:
![image](https://github.com/user-attachments/assets/6ba70274-db40-48d0-8077-51da301732a0)
![image](https://github.com/user-attachments/assets/6e9783ae-a170-44f3-a39a-bf7d8d925d47)

production:
![image](https://github.com/user-attachments/assets/afda598e-0148-4ab7-97f9-f660f33be799)
![image](https://github.com/user-attachments/assets/f3e2ea76-003a-4419-81f2-ff061b1a13ee)

What we need to add:
  ckan.deployment_env.type = production
  ckan.deployment_env.banner_message = 'production'

values are 'development', 'staging' and 'production', other values possible by adding more css classes in _banner.scss
## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
